### PR TITLE
:bug: (fixture) GroupSeeder was crashing when updating database

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,11 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true,
+            "symfony/runtime": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bc09415a194c16e628527b7b29145a0",
+    "content-hash": "b1a284b9073494890edbe5287cbce7a2",
     "packages": [
         {
             "name": "api-platform/core",
@@ -9729,16 +9729,16 @@
         },
         {
             "name": "doctrine/doctrine-fixtures-bundle",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
-                "reference": "870189619a7770f468ffb0b80925302e065a3b34"
+                "reference": "31ba202bebce0b66fe830f49f96228dcdc1503e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/870189619a7770f468ffb0b80925302e065a3b34",
-                "reference": "870189619a7770f468ffb0b80925302e065a3b34",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/31ba202bebce0b66fe830f49f96228dcdc1503e7",
+                "reference": "31ba202bebce0b66fe830f49f96228dcdc1503e7",
                 "shasum": ""
             },
             "require": {
@@ -9747,16 +9747,18 @@
                 "doctrine/orm": "^2.6.0",
                 "doctrine/persistence": "^1.3.7|^2.0",
                 "php": "^7.1 || ^8.0",
-                "symfony/config": "^3.4|^4.3|^5.0",
-                "symfony/console": "^3.4|^4.3|^5.0",
-                "symfony/dependency-injection": "^3.4|^4.3|^5.0",
-                "symfony/doctrine-bridge": "^3.4|^4.1|^5.0",
-                "symfony/http-kernel": "^3.4|^4.3|^5.0"
+                "symfony/config": "^3.4|^4.3|^5.0|^6.0",
+                "symfony/console": "^3.4|^4.3|^5.0|^6.0",
+                "symfony/dependency-injection": "^3.4.47|^4.3|^5.0|^6.0",
+                "symfony/doctrine-bridge": "^3.4|^4.1|^5.0|^6.0",
+                "symfony/http-kernel": "^3.4|^4.3|^5.0|^6.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
+                "phpstan/phpstan": "^0.12.99",
                 "phpunit/phpunit": "^7.4 || ^8.0 || ^9.2",
-                "symfony/phpunit-bridge": "^4.1|^5.0"
+                "symfony/phpunit-bridge": "^4.1|^5.0|^6.0",
+                "vimeo/psalm": "^4.10"
             },
             "type": "symfony-bundle",
             "autoload": {
@@ -9790,7 +9792,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineFixturesBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineFixturesBundle/tree/3.4.0"
+                "source": "https://github.com/doctrine/DoctrineFixturesBundle/tree/3.4.1"
             },
             "funding": [
                 {
@@ -9806,7 +9808,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-14T09:36:49+00:00"
+            "time": "2021-10-28T05:46:28+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -10758,5 +10760,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * A Group of User for friends, Course... Only user can see it, only god can judge me.
  *
  * @ORM\Entity(repositoryClass=GroupRepository::class)
- * @ORM\Table(name="groups")
+ * @ORM\Table(name="`groups`")
  * @ORM\EntityListeners({"App\Doctrine\GroupSetAdminAndMemberListener"})
  */
 #[


### PR DESCRIPTION
groups is a keyword in mysql, so I replaced the table name in the code (App\Entity\Group) by `groups`. Using `...` tells mysql that
the content has to be evaluated, and is not a keyword

<!--
Thank you for your contribution !

This is the model of Pull Request (PR) to complete.
It is required to explain your work, and make sure you have done everything perfectly !
-->


## Description

<!-- Describe here what you have done -->


## Checklist

<!-- Check the boxes by filling [ ] with an "x" as follows : [x] -->

### Test
<!-- The checklist for the tests, not implemented yet. -->

### Implementation

* [ ] Files and variables have a name explaining what they do.
* [ ] Updating the DB schemas and seeding the tables do not generates errors.
* [ ] All code repeted more than 2 times has been refactored in a dedicated file or function.
* [ ] Debugs have been removed : `dd()` | `dump()`

### Tools

* [ ] PHP CS Fixer has fixed all files inside the `src` folder.
* [ ] All commits have been done using Commitizen.

### Documentation

* [ ] All new classes and non-trivial functions have a code documentation.
* [ ] There are comments to explain complex parts inside your code.
* [ ] If a new folder is created, it has been added and explained inside the "Folder structure" part of the `README.md` file.